### PR TITLE
Optimize genotype table construction

### DIFF
--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -580,7 +580,7 @@
 						gotMetaData = true;
 					if (gotMetaData)
 						for (var key in callSetResponse[ind].info)
-							if (!arrayContains(headers, key))
+							if (!headers.includes(key))
 								headers.push(key);
 					if (individualSubSet == null || $.inArray(callSetResponse[ind].name, individualSubSet) != -1)
 						indOpt.push(callSetResponse[ind].name);
@@ -941,8 +941,8 @@
 		{
 			var annotationThresholds = !checkThresholds ? null : getAnnotationThresholds(gtTable[row][0], indArray1, indArray2);
 			htmlTableContents.append('<tr>');
-			var inGroup1 = indArray1.length == 0 || arrayContains(indArray1, gtTable[row][0]);
-			var inGroup2 = $('#genotypeInvestigationDiv2').is(':visible') && (indArray2.length == 0 || arrayContains(getSelectedIndividuals(2), gtTable[row][0]));
+			var inGroup1 = indArray1.length == 0 || indArray1.includes(gtTable[row][0]);
+			var inGroup2 = $('#genotypeInvestigationDiv2').is(':visible') && (indArray2.length == 0 || indArray2.includes(gtTable[row][0]));
 			for (var i=0; i<tableHeader.length; i++)
 			{
 				var indivClass = inGroup1 ? (inGroup2 ? "groups1and2" : "group1") : (inGroup2 ? "group2" : "");
@@ -1115,7 +1115,7 @@
 			supportedTypes = supportedTypes.split(";");
 			var selectedTypes = $('#variantTypes').val() === null ? Array.from($('#variantTypes option')).map(opt => opt.innerText) : $('#variantTypes').val();
 			for (var i in selectedTypes)
-				if (!arrayContains(supportedTypes, selectedTypes[i])) {
+				if (!supportedTypes.includes(selectedTypes[i])) {
 					alert("Error: selected export format does not support variant type " + selectedTypes[i]);
 					return;
 				}
@@ -1124,7 +1124,7 @@
 		if (supportedPloidyLevels != null && supportedPloidyLevels !== undefined && supportedPloidyLevels != "undefined") {
 			supportedPloidyLevels = supportedPloidyLevels.toString().split(";");
 			console.log(supportedPloidyLevels);
-			if (!arrayContains(supportedPloidyLevels, ploidy)) {
+			if (!supportedPloidyLevels.includes(ploidy)) {
 				alert("Error: selected export format does not support ploidy level " + ploidy);
 				return;
 			}
@@ -1249,7 +1249,7 @@
 				var toolConfig = getOutputToolConfig(toolName);
 				var buttonsForThisTool = "";
 				for (var key in archivedDataFiles)
-					if (toolConfig['url'] != null && toolConfig['url'].trim() != "" && (toolConfig['formats'] == null || toolConfig['formats'].trim() == "" || arrayContains(toolConfig['formats'].toUpperCase().split(","), $('#exportFormat').val().toUpperCase())))
+					if (toolConfig['url'] != null && toolConfig['url'].trim() != "" && (toolConfig['formats'] == null || toolConfig['formats'].trim() == "" || toolConfig['formats'].toUpperCase().split(",").includes($('#exportFormat').val().toUpperCase())))
 						buttonsForThisTool += '&nbsp;<input type="button" value="Send ' + key.toUpperCase() + ' file to ' + toolName + '" onclick="window.open(\'' + toolConfig['url'].replace(/\*/g, escape(archivedDataFiles[key])) + '\');" />&nbsp;';
 				
 				if (buttonsForThisTool != "");

--- a/src/main/webapp/js/main.js
+++ b/src/main/webapp/js/main.js
@@ -698,8 +698,9 @@ function getSelectedIndividuals(groupNumber, provideGa4ghId) {
 		// All individuals are selected in a single group, no need to look further
 		if (groupIndividuals.length == indCount)
 		    return [];
-		for (var indKey in groupIndividuals)
-			selectedIndividuals.add((provideGa4ghId ? ga4ghId : "") + groupIndividuals[indKey]);
+		groupIndividuals.forEach(function (individual) {
+		    selectedIndividuals.add((provideGa4ghId ? ga4ghId : "") + individual);
+		});
 	}
 	return selectedIndividuals.size == indCount ? [] : Array.from(selectedIndividuals);
 }

--- a/src/main/webapp/js/main.js
+++ b/src/main/webapp/js/main.js
@@ -687,20 +687,21 @@ function markAsMissingData(individual) {
 }
 
 function getSelectedIndividuals(groupNumber, provideGa4ghId) {
-	var selectedIndividuals = new Set();
-	var groups = groupNumber == null ? [1, 2] : [groupNumber];
-	var ga4ghId = getProjectId() + "§";
-	for (var groupKey in groups)
+	const selectedIndividuals = new Set();
+	const groups = groupNumber == null ? [1, 2] : [groupNumber];
+	const ga4ghId = getProjectId() + "§";
+	for (let groupKey in groups)
 	{
-		var groupIndividuals = $('#Individuals' + groups[groupKey]).selectmultiple('value');
+	    const groupIndex = groups[groupKey];
+		let groupIndividuals = $('#Individuals' + groupIndex).selectmultiple('value');
 		if (groupIndividuals == null)
-			groupIndividuals = $('#Individuals' + groups[groupKey]).selectmultiple('option');
+			groupIndividuals = $('#Individuals' + groupIndex).selectmultiple('option');
 		// All individuals are selected in a single group, no need to look further
 		if (groupIndividuals.length == indCount)
 		    return [];
-		groupIndividuals.forEach(function (individual) {
-		    selectedIndividuals.add((provideGa4ghId ? ga4ghId : "") + individual);
-		});
+		
+		for (let indKey in groupIndividuals)
+			selectedIndividuals.add((provideGa4ghId ? ga4ghId : "") + groupIndividuals[indKey]);
 	}
 	return selectedIndividuals.size == indCount ? [] : Array.from(selectedIndividuals);
 }

--- a/src/main/webapp/js/main.js
+++ b/src/main/webapp/js/main.js
@@ -27,14 +27,6 @@ function isHex(h) {
 	return (a.toString(16) === h.toLowerCase())
 }
 
-function arrayContains(array, element) 
-{
-	for (var i = 0; i < array.length; i++) 
-		if (array[i] == element) 
-			return true;
-	return false;
-};
-
 function arrayContainsIgnoreCase(array, element)
 {
 	for (var i = 0; i < array.length; i++) 
@@ -672,7 +664,7 @@ function markInconsistentGenotypesAsMissing() {
 				genotypes = new Array();
 
 			var genotype = $(this).find("td:eq(0)").html().trim();
-			if (!arrayContains(genotypes, genotype))
+			if (!genotypes.includes(genotype))
 				genotypes.push(genotype);
 			indivGenotypes[individual] = genotypes;
 
@@ -695,19 +687,21 @@ function markAsMissingData(individual) {
 }
 
 function getSelectedIndividuals(groupNumber, provideGa4ghId) {
-	var selectedIndividuals = [];
+	var selectedIndividuals = new Set();
 	var groups = groupNumber == null ? [1, 2] : [groupNumber];
 	var ga4ghId = getProjectId() + "§";
 	for (var groupKey in groups)
 	{
 		var groupIndividuals = $('#Individuals' + groups[groupKey]).selectmultiple('value');
 		if (groupIndividuals == null)
-			groupIndividuals = $('#Individuals' + groups[groupKey]).selectmultiple('option')
+			groupIndividuals = $('#Individuals' + groups[groupKey]).selectmultiple('option');
+		// All individuals are selected in a single group, no need to look further
+		if (groupIndividuals.length == indCount)
+		    return [];
 		for (var indKey in groupIndividuals)
-			if (!arrayContains(selectedIndividuals, groupIndividuals[indKey]))
-				selectedIndividuals.push((provideGa4ghId ? ga4ghId : "") + groupIndividuals[indKey]);
+			selectedIndividuals.add((provideGa4ghId ? ga4ghId : "") + groupIndividuals[indKey]);
 	}
-	return selectedIndividuals.length == indCount ? [] : selectedIndividuals;
+	return selectedIndividuals.size == indCount ? [] : Array.from(selectedIndividuals);
 }
 
 function getAllSelectedIndividuals(provideGa4ghId){
@@ -733,7 +727,7 @@ function getAnnotationThresholds(individual, indArray1, indArray2)
 {
 	var annotationFieldThresholds1 = {}, annotationFieldThresholds2 = {}, result = {};
 
-	var inGroup1 = indArray1.length == 0 || arrayContains(indArray1, individual);
+	var inGroup1 = indArray1.length == 0 || indArray1.includes(individual);
 	if (inGroup1)
 		$('#vcfFieldFilterGroup1 input').each(function() {
 			var value = $(this).val();
@@ -741,7 +735,7 @@ function getAnnotationThresholds(individual, indArray1, indArray2)
 				result[this.id.substring(0, this.id.lastIndexOf("_"))] = parseFloat(value);
 		});
 	
-	var inGroup2 = indArray2.length == 0 || arrayContains(indArray2, individual);
+	var inGroup2 = indArray2.length == 0 || indArray2.includes(individual);
 	if (inGroup2)
 		$('#vcfFieldFilterGroup2 input').each(function() {
 			var value = $(this).val();
@@ -937,7 +931,7 @@ function addSelectionDropDownsToHeaders(tableObj)
 			{
 				if (containsHtmlTags(tableObj.rows[r].cells[c].innerHTML))
 					continue mainLoop;	// we don't create filter drop-downs for HTML contents
-				if (!arrayContains(distinctValuesForColumn, tableObj.rows[r].cells[c].innerHTML))
+				if (!distinctValuesForColumn.includes(tableObj.rows[r].cells[c].innerHTML))
 					distinctValuesForColumn[distinctValuesForColumn.length] = tableObj.rows[r].cells[c].innerHTML;
 			}
 
@@ -984,7 +978,7 @@ function applyDropDownFiltersToTable(tableObj)
 			if (filtersToColumns[c] != null)
 			{
 				var selection = $(filtersToColumns[c]).val();
-				if (selection != null && tableObj.rows[r].cells[c] != null && !arrayContains(selection, tableObj.rows[r].cells[c].innerHTML))
+				if (selection != null && tableObj.rows[r].cells[c] != null && !selection.includes(tableObj.rows[r].cells[c].innerHTML))
 				{
 					displayVal = "none";
 					if (r > 1)


### PR DESCRIPTION
The genotype table had very slow loading (~1min30 for 3000 individuals) because of some unnecessary computations in index.jsp:buildGenotypeTableContents and main.js:getSelectedIndividuals
This also removes the arrayContains function in favor of the built-in (and faster) Array.includes method