### PR TITLE
Allow Cross Origin for genotype import API

### DIFF
--- a/src/main/java/fr/cirad/web/controller/gigwa/GigwaRestController.java
+++ b/src/main/java/fr/cirad/web/controller/gigwa/GigwaRestController.java
@@ -245,6 +245,7 @@ public class GigwaRestController extends ControllerInterface {
 	 */
 	@ApiOperation(authorizations = { @Authorization(value = "AuthorizationToken") }, value = GET_SESSION_TOKEN, notes = "Generate a token. The obtained token then needs to be passed along with every request.")
 	@ApiResponses(value = { @ApiResponse(code = 200, message = "Success") })
+	@CrossOrigin
 	@RequestMapping(value = BASE_URL + GET_SESSION_TOKEN, method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
 	public Map<String, String> generateToken(HttpServletRequest request, HttpServletResponse response, @RequestBody(required = false) UserInfo userInfo) throws IllegalArgumentException, UnsupportedEncodingException {
         if (userInfo != null && (userInfo.getUsername() == null || userInfo.getUsername().isEmpty() ||  userInfo.getPassword() == null || userInfo.getPassword().isEmpty())) {
@@ -544,6 +545,7 @@ public class GigwaRestController extends ControllerInterface {
 	@ApiOperation(authorizations = { @Authorization(value = "AuthorizationToken") }, value = PROGRESS_PATH, notes = "Get the progress status of a process from its token. If no current process is associated with this token, returns null")
 	@ApiResponses(value = { @ApiResponse(code = 200, message = "Success"), 
 							@ApiResponse(code = 204, message = "No progress indicator") })
+	@CrossOrigin
 	@RequestMapping(value = BASE_URL + PROGRESS_PATH, method = RequestMethod.GET, produces = "application/json")
 	public ProgressIndicator getProcessProgress(HttpServletRequest request, HttpServletResponse response) {
 		String token = tokenManager.readToken(request);
@@ -1484,6 +1486,7 @@ public class GigwaRestController extends ControllerInterface {
 	 * @throws Exception the exception
 	 */
 	@ApiOperation(authorizations = { @Authorization(value = "AuthorizationToken") }, value = genotypeImportSubmissionURL, notes = "Import genotyping data.")
+	@CrossOrigin
 	@RequestMapping(value = BASE_URL + genotypeImportSubmissionURL, method = RequestMethod.POST)
 	public @ResponseBody String importGenotypingData(HttpServletRequest request, HttpServletResponse response,
 			@RequestParam(value = "host", required = false) String sHost, @RequestParam(value = "module", required = false) final String sModule,


### PR DESCRIPTION
/rest/gigwa genotypeImport, progress, and generateToken

These three endpoints are required to import a genotype using the API. With out cross-origin enabled, an import cannot be started when Gigwa is on a different server.

Perhaps a rule for which endpoints should be cross-origin should be decided on, or enable it on all endpoints.